### PR TITLE
【timechecker】累計時間の更新の仕組みを変更(Close #4)

### DIFF
--- a/timechecker/README.md
+++ b/timechecker/README.md
@@ -11,6 +11,10 @@
 
 ## Release Notes
 
+### 1.0.0
+
+1.0.0 Released!
+
 ### 0.0.10 ~ 0.0.11
 
 small bugs was fixed

--- a/timechecker/package.json
+++ b/timechecker/package.json
@@ -7,7 +7,7 @@
 		"type": "git",
 		"url": "https://github.com/okaryo/VSCodeExtension/tree/master/timechecker"
 	},
-	"version": "0.0.11",
+	"version": "1.0.0",
 	"engines": {
 		"vscode": "^1.40.0"
 	},

--- a/timechecker/src/extension.ts
+++ b/timechecker/src/extension.ts
@@ -2,16 +2,16 @@ import * as vscode from 'vscode';
 import * as dayjs from 'dayjs';
 
 let myStatusBarItem: vscode.StatusBarItem;
-const oneDayTime: number = 60 * 60 * 24;
 
 export function activate(context: vscode.ExtensionContext) {
 	myStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 1000);
+	const startDate: number = dayjs().date();
 	let totalTime: number = 0;
-	
 
 	setInterval(() => {
 		if (vscode.window.state.focused) {
-			if (totalTime === oneDayTime) {
+			let nowDate: number = dayjs().date();
+			if (startDate !== nowDate) {
 				totalTime = 0;
 			}
       totalTime ++;


### PR DESCRIPTION
## 概要
- 累計時間は24時間になった時0にリセットされるようになっているが、日にちを跨いだときにリセットするよう変更

## 備考
- テスト書かないと…